### PR TITLE
feat: enable message intents

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -13,7 +13,7 @@ const { registerCommands } = await import('#commands');
 
 const client = new Client<true>({
   shards: 'auto',
-  intents: [GatewayIntentBits.Guilds],
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
   presence: {
     status: 'online',
     activities: [


### PR DESCRIPTION
## Summary
- allow the bot to receive guild messages and message content by enabling those intents

## Testing
- `npm test`
- `npx tsx <<'EOF'...EOF`

------
https://chatgpt.com/codex/tasks/task_b_68a9b901e350832988b786ad0943c8d1