### PR TITLE
feat: add Polli client with optional token

### DIFF
--- a/src/ai/polliClient.ts
+++ b/src/ai/polliClient.ts
@@ -1,0 +1,14 @@
+import { Polli } from '../polli';
+
+import { config } from '#config';
+import { logger } from '#utils/logger';
+
+let polliClient: Polli | null = null;
+
+if (!config.pollinationsToken) {
+  logger.error('Missing Pollinations token. Skipping LLM features.');
+} else {
+  polliClient = new Polli({ token: config.pollinationsToken, referrer: 'WaliBot' });
+}
+
+export { polliClient };


### PR DESCRIPTION
## Summary
- add Polli client instantiation using config token and WaliBot referrer
- log an error and export null when Pollinations token is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9ba4f9ed083299e5fcd77f8202c95