### PR TITLE
Format tool outputs as Markdown

### DIFF
--- a/src/ai/formatters.ts
+++ b/src/ai/formatters.ts
@@ -1,0 +1,90 @@
+import type { ContractModel, ItemModel, NpcModel, PlaceableModel, SkillModel } from '#types/database';
+
+const formatList = (items: string[]): string => items.map((item) => `- ${item}`).join('\n');
+
+export const formatItem = (item: ItemModel): string => {
+  const lines: string[] = [`**${item.name ?? 'Unknown Item'}**`];
+  const description = item.shortDescription || item.description;
+  if (description) lines.push('', description);
+
+  const details: string[] = [];
+  if (item.tier !== undefined) details.push(`Tier: ${item.tier}`);
+  if (item.filterCategoryIds?.length) details.push(`Categories: ${item.filterCategoryIds.join(', ')}`);
+  if (details.length) lines.push('', formatList(details));
+
+  return lines.join('\n');
+};
+
+export const formatBuilding = (building: PlaceableModel): string => {
+  const lines: string[] = [`**${building.name ?? 'Unknown Building'}**`];
+  if (building.description) lines.push('', building.description);
+
+  const details: string[] = [];
+  if (building.faction) details.push(`Faction: ${building.faction}`);
+  if (building.buildableTier) details.push(`Tier: ${building.buildableTier}`);
+  if (details.length) lines.push('', formatList(details));
+
+  if (building.ingredients?.length) {
+    lines.push(
+      '',
+      'Ingredients:',
+      formatList(
+        building.ingredients.map((ing) => {
+          const name = ing.entity?.name || ing.entity?.id || 'Unknown';
+          const qty = ing.quantity ?? '?';
+          return `${qty} x ${name}`;
+        })
+      )
+    );
+  }
+
+  return lines.join('\n');
+};
+
+export const formatSkill = (skill: SkillModel): string => {
+  const lines: string[] = [`**${skill.name ?? 'Unknown Skill'}**`];
+  if (skill.description) lines.push('', skill.description);
+
+  const details: string[] = [];
+  if (skill.skillTree) details.push(`Tree: ${skill.skillTree}`);
+  if (skill.maxLevel !== undefined) details.push(`Max Level: ${skill.maxLevel}`);
+  if (details.length) lines.push('', formatList(details));
+
+  return lines.join('\n');
+};
+
+export const formatContract = (contract: ContractModel): string => {
+  const lines: string[] = [`**${contract.name ?? 'Unknown Contract'}**`];
+  if (contract.description) lines.push('', contract.description);
+
+  if (contract.conditions?.length) {
+    lines.push(
+      '',
+      'Conditions:',
+      formatList(contract.conditions.map((c) => c.name || c.conditionType || 'Unknown condition'))
+    );
+  }
+
+  return lines.join('\n');
+};
+
+export const formatNpc = (npc: NpcModel): string => {
+  const lines: string[] = [`**${npc.name ?? 'Unknown NPC'}**`];
+  if (npc.description) lines.push('', npc.description);
+
+  const details: string[] = [];
+  if (npc.hostilityType) details.push(`Hostility: ${npc.hostilityType}`);
+  if (details.length) lines.push('', formatList(details));
+
+  if (npc.sellsItems?.length) {
+    lines.push('', 'Sells:', formatList(npc.sellsItems.map((i) => i.entity?.name || i.entity?.id || 'Unknown')));
+  }
+
+  if (npc.buysItems?.length) {
+    lines.push('', 'Buys:', formatList(npc.buysItems.map((i) => i.entity?.name || i.entity?.id || 'Unknown')));
+  }
+
+  return lines.join('\n');
+};
+
+export default { formatItem, formatBuilding, formatSkill, formatContract, formatNpc };

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '../polli';
+import { formatBuilding, formatContract, formatItem, formatNpc, formatSkill } from './formatters';
 
 import type { ContractModel, ItemModel, NpcModel, PlaceableModel, SkillModel } from '#types/database';
 import { api } from '#utils/api';
@@ -14,11 +15,26 @@ const searchAndGet = async <T>(query: string, type: string): Promise<T | null> =
 };
 
 export const exec = {
-  get_item: async ({ query }: { query: string }) => searchAndGet<ItemModel>(query, 'items'),
-  get_building: async ({ query }: { query: string }) => searchAndGet<PlaceableModel>(query, 'buildables'),
-  get_skill: async ({ query }: { query: string }) => searchAndGet<SkillModel>(query, 'skills'),
-  get_contract: async ({ query }: { query: string }) => searchAndGet<ContractModel>(query, 'contracts'),
-  get_npc: async ({ query }: { query: string }) => searchAndGet<NpcModel>(query, 'npcs'),
+  get_item: async ({ query }: { query: string }) => {
+    const item = await searchAndGet<ItemModel>(query, 'items');
+    return item ? formatItem(item) : `No item found for "${query}".`;
+  },
+  get_building: async ({ query }: { query: string }) => {
+    const building = await searchAndGet<PlaceableModel>(query, 'buildables');
+    return building ? formatBuilding(building) : `No building found for "${query}".`;
+  },
+  get_skill: async ({ query }: { query: string }) => {
+    const skill = await searchAndGet<SkillModel>(query, 'skills');
+    return skill ? formatSkill(skill) : `No skill found for "${query}".`;
+  },
+  get_contract: async ({ query }: { query: string }) => {
+    const contract = await searchAndGet<ContractModel>(query, 'contracts');
+    return contract ? formatContract(contract) : `No contract found for "${query}".`;
+  },
+  get_npc: async ({ query }: { query: string }) => {
+    const npc = await searchAndGet<NpcModel>(query, 'npcs');
+    return npc ? formatNpc(npc) : `No NPC found for "${query}".`;
+  },
 };
 
 export const tools: Tool[] = [


### PR DESCRIPTION
## Summary
- add formatter helpers to convert API models into Markdown strings
- return formatted Markdown from tool executors for immediate readability

## Testing
- `npm test`
- `npm run build` *(fails: relative import paths need explicit file extensions)*

------
https://chatgpt.com/codex/tasks/task_b_68a9bee3f7a88329a8096c4f256ebda7