### PR TITLE
test: expand utility coverage

### DIFF
--- a/tests/utils/api.test.ts
+++ b/tests/utils/api.test.ts
@@ -1,0 +1,123 @@
+import { api } from '../../src/utils/api';
+import { cache } from '../../src/utils/cache';
+import { config } from '../../src/config';
+import { logger } from '../../src/utils/logger';
+import type { SearchEntry } from '../../src/types/database';
+import { vi } from 'vitest';
+
+const originalFetch = global.fetch;
+
+describe('api utilities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cache.clear();
+    config.secretToken = undefined;
+    global.fetch = originalFetch;
+  });
+
+  it('returns cached data without fetching', async () => {
+    cache.set('en/test', { value: 1 });
+    const fetchMock = vi.fn();
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    const result = await api.get<{ value: number }>('test', 'en');
+    expect(result).toEqual({ value: 1 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches data and caches it with secret token', async () => {
+    config.secretToken = 'secret';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 2 }),
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    const result = await api.get<{ value: number }>('test', 'en');
+    expect(result).toEqual({ value: 2 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('en/test'),
+      { headers: { 'X-Secret-Token': 'secret' } }
+    );
+    expect(cache.get('en/test')).toEqual({ value: 2 });
+  });
+
+  it('handles non-ok response', async () => {
+    const errSpy = vi.spyOn(logger, 'error').mockReturnValue();
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await api.get('test', 'en');
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('handles json syntax error', async () => {
+    const errSpy = vi.spyOn(logger, 'error').mockReturnValue();
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockRejectedValue(new SyntaxError('bad')),
+    });
+
+    const result = await api.get('test', 'en');
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Syntax error')
+    );
+  });
+
+  it('handles fetch failure', async () => {
+    const errSpy = vi.spyOn(logger, 'error').mockReturnValue();
+    // @ts-ignore
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+
+    const result = await api.get('test', 'en');
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch')
+    );
+  });
+
+  it('search returns empty array when no data', async () => {
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    const result = await api.search('en');
+    expect(result).toEqual([]);
+  });
+
+  it('search filters by types', async () => {
+    const data: SearchEntry[] = [
+      { path: 'type1/foo', name: 'Foo' },
+      { path: 'type2/bar', name: 'Bar' },
+      { name: 'NoPath' },
+    ];
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(data),
+    });
+
+    const result = await api.search('en', undefined, ['type1']);
+    expect(result).toEqual([{ path: 'type1/foo', name: 'Foo' }]);
+  });
+
+  it('search filters by query', async () => {
+    const data: SearchEntry[] = [
+      { path: 'type1/foo', name: 'Alpha.*' },
+      { path: 'type1/bar', name: 'Beta' },
+    ];
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(data),
+    });
+
+    const result = await api.search('en', 'Alpha.*');
+    expect(result).toEqual([{ path: 'type1/foo', name: 'Alpha.*' }]);
+  });
+});
+

--- a/tests/utils/canvas.test.ts
+++ b/tests/utils/canvas.test.ts
@@ -1,0 +1,25 @@
+import { vi } from 'vitest';
+
+vi.mock('@napi-rs/canvas', () => ({
+  createCanvas: vi.fn((width, height) => ({
+    getContext: () => ({ fillStyle: '', fillRect: vi.fn() }),
+    toBuffer: () => Buffer.from('image'),
+  })),
+}));
+
+import { createColorPaletteImage } from '../../src/utils/canvas';
+import { createCanvas } from '@napi-rs/canvas';
+
+describe('createColorPaletteImage', () => {
+  it('creates an image from provided colors', () => {
+    const buf = createColorPaletteImage(['#ff0000', '#00ff00']);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(createCanvas).toHaveBeenCalledWith(140, 60);
+  });
+
+  it('throws if colors are missing', () => {
+    expect(() => createColorPaletteImage(null)).toThrow('No colors provided');
+    expect(() => createColorPaletteImage([])).toThrow('No colors provided');
+  });
+});
+

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,11 @@
+import { logger } from '../../src/utils/logger';
+
+describe('logger utility', () => {
+  it('logs messages without throwing', () => {
+    expect(() => {
+      logger.info('info');
+      logger.error('error');
+    }).not.toThrow();
+  });
+});
+

--- a/tests/utils/prometheus.test.ts
+++ b/tests/utils/prometheus.test.ts
@@ -1,0 +1,21 @@
+import {
+  commandCounter,
+  commandFailureCounter,
+  commandSuccessCounter,
+  totalGuilds,
+  totalUsers,
+} from '../../src/utils/prometheus';
+
+describe('prometheus metrics', () => {
+  it('updates counters and gauges without throwing', () => {
+    expect(() => {
+      totalGuilds.set(5);
+      totalUsers.set({ guildId: '1' }, 10);
+      const labels = { commandType: 'slash', type: 'chat', commandName: 'test' };
+      commandCounter.inc(labels);
+      commandSuccessCounter.inc(labels);
+      commandFailureCounter.inc(labels);
+    }).not.toThrow();
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   test: {
@@ -6,11 +11,18 @@ export default defineConfig({
     globals: true,
     coverage: {
       reporter: ['text'],
-      include: ['src/utils/cache.ts', 'src/utils/common.ts'],
+      include: ['src/utils/*.ts'],
       lines: 80,
       functions: 80,
       branches: 80,
       statements: 80,
+    },
+  },
+  resolve: {
+    alias: {
+      '#config': path.resolve(__dirname, './src/config.ts'),
+      '#utils': path.resolve(__dirname, './src/utils'),
+      '#types': path.resolve(__dirname, './src/types'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- expand vitest coverage to all utilities with path aliases
- add thorough tests for API, canvas, logger and Prometheus helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9d4f9105c8329acf50c186353ef46