### PR TITLE
Ensure embedded Postgres binary is executable

### DIFF
--- a/scripts/setupDatabase.ts
+++ b/scripts/setupDatabase.ts
@@ -1,6 +1,27 @@
 import EmbeddedPostgres from 'embedded-postgres';
-import { existsSync } from 'fs';
+import {
+  accessSync,
+  constants,
+  existsSync,
+  chmodSync,
+} from 'fs';
 import path from 'path';
+import { createRequire } from 'module';
+
+// Ensure the embedded postgres binaries are executable
+const require = createRequire(import.meta.url);
+const embeddedMain = require.resolve('@embedded-postgres/linux-x64');
+const initdbPath = path.resolve(
+  path.dirname(embeddedMain),
+  '..',
+  'native/bin/initdb',
+);
+
+try {
+  accessSync(initdbPath, constants.X_OK);
+} catch {
+  chmodSync(initdbPath, 0o755);
+}
 
 const dataDir = './data/db';
 


### PR DESCRIPTION
## Summary
- ensure embedded Postgres `initdb` is executable during setup

## Testing
- `npm test`
- `npx tsx scripts/setupDatabase.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a9db3ca7308329a03537f2c045808d